### PR TITLE
Add Hardware Cyanogen

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -550,6 +550,7 @@
   <project path="hardware/qcom/media-caf/msm8996" name="lineageos/android_hardware_qcom_media" groups="qcom" remote="github" revision="cm-14.1-caf-8996" />
   <project path="hardware/qcom/wlan" name="lineageos/android_hardware_qcom_wlan" groups="qcom_wlan" remote="github" revision="cm-14.1" />
   <project path="hardware/qcom/wlan-caf" name="LineageOS/android_hardware_qcom_wlan" groups="qcom_wlan" remote="github" revision="cm-14.1-caf" />
+  <project path="hardware/cyanogen" name="LineageOS/android_hardware_cyanogen" groups="pdk" remote="github" revision="cm-14.1" />
 
   <!-- Linux packages -->
   <project path="prebuilts/clang/linux-x86/host/3.6" name="platform/prebuilts/clang/linux-x86/host/3.6" groups="pdk,linux" />


### PR DESCRIPTION
Some devices need this for LED to function and also screen brightness.