### PR TITLE
manifest: Fix derp

### DIFF
--- a/snippets/aex.xml
+++ b/snippets/aex.xml
@@ -135,7 +135,7 @@
   <project path="external/bash" name="android_external_bash" remote="los" />
   <project path="external/brctl" name="android_external_brctl" remote="los" />
   <project path="external/powertop" name="android_external_powertop" remote="los" />
-  <project path="external/chromium-libpa" name="android_external_chromium-libpa" remote="los" />
+  <project path="external/chromium-libpac" name="android_external_chromium-libpac" remote="los" />
   <project path="external/connectivity" name="android_external_connectivity" groups="pdk" remote="los" />
   <project path="external/ebtables" name="android_external_ebtables" groups="pdk" remote="los" />
   <project path="external/exfat" name="android_external_exfat" remote="los" />


### PR DESCRIPTION
 * Its correct name in LineageOS is android_external_chromium-libpac.
 * Thanks @skulko (https://github.com/AospExtended/manifest/issues/70).

Signed-off-by: TH779 <tongsj2333@gmail.com>
Change-Id: I664e3601c3396ddfc08410ece3196e4ff195ecb7